### PR TITLE
Added 7 readers and extended unit tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,9 +7,9 @@ ColumnLimit: 100
 
 Language: Cpp
 AccessModifierOffset: -2
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 BreakConstructorInitializersBeforeComma: true
@@ -19,7 +19,7 @@ IndentCaseLabels: false
 NamespaceIndentation: None
 PointerAlignment: Middle
 SortIncludes: true
-Standard: Cpp11
+Standard: c++17
 
 IncludeBlocks:   Preserve
 IncludeCategories:

--- a/tests/data/sample_feed/attributions.txt
+++ b/tests/data/sample_feed/attributions.txt
@@ -1,0 +1,2 @@
+attribution_id,organization_name,is_producer,is_operator,is_authority,attribution_url
+0,Test inc,1,0,0,"https://test.pl/gtfs/"

--- a/tests/data/sample_feed/feed_info.txt
+++ b/tests/data/sample_feed/feed_info.txt
@@ -1,0 +1,2 @@
+feed_publisher_name,feed_publisher_url,feed_lang,feed_version,feed_license
+"Test Solutions, Inc.",http://test,en,,

--- a/tests/data/sample_feed/levels.txt
+++ b/tests/data/sample_feed/levels.txt
@@ -1,0 +1,4 @@
+level_id,level_index,level_name
+U321L1,-1.5,"Vestibul"
+U321L2,-2,"Vestibul2"
+U321L0,0,"Povrch"

--- a/tests/data/sample_feed/pathways.txt
+++ b/tests/data/sample_feed/pathways.txt
@@ -1,0 +1,4 @@
+pathway_id,from_stop_id,to_stop_id,pathway_mode,signposted_as,reversed_signposted_as,is_bidirectional
+T-A01C01,1073S,1098E,2,"Sign1","Sign2",1
+T-A01D01,1075S,1118S,1,"Sign4",,0
+T-A01D01,1075N,1118N,1,,,1

--- a/tests/data/sample_feed/transfers.txt
+++ b/tests/data/sample_feed/transfers.txt
@@ -1,0 +1,5 @@
+from_stop_id,to_stop_id,transfer_type,min_transfer_time
+130,4,2,70
+227,4,0,160
+314,11,1,
+385,11,2,

--- a/tests/data/sample_feed/translations.txt
+++ b/tests/data/sample_feed/translations.txt
@@ -1,0 +1,2 @@
+table_name,field_name,language,translation,record_id,record_sub_id,field_value
+stop_times,stop_headsign,en,"Downtown",,,


### PR DESCRIPTION
Csv-readers for: fare_attributes, fare_rules, pathways, levels, feed_info, translations, attributions. Unit tests for all readers.

Reference to specification:
https://developers.google.com/transit/gtfs/reference