### PR TITLE
Parse time >= 100 hours for multi-day routes.

### DIFF
--- a/include/just_gtfs/just_gtfs.h
+++ b/include/just_gtfs/just_gtfs.h
@@ -516,8 +516,8 @@ inline Time::Time(const std::string & raw_time_str) : raw_time(raw_time_str)
     return;
 
   const size_t len = raw_time.size();
-  if (!(len == 7 || len == 8) || (raw_time[len - 3] != ':' && raw_time[len - 6] != ':'))
-    throw InvalidFieldFormat("Time is not in [H]H:MM:SS format: " + raw_time_str);
+  if (!(len >= 7 && len <= 9) || (raw_time[len - 3] != ':' && raw_time[len - 6] != ':'))
+    throw InvalidFieldFormat("Time is not in [[H]H]H:MM:SS format: " + raw_time_str);
 
   hh = static_cast<uint16_t>(std::stoi(raw_time.substr(0, len - 6)));
   mm = static_cast<uint16_t>(std::stoi(raw_time.substr(len - 5, 2)));

--- a/include/just_gtfs/just_gtfs.h
+++ b/include/just_gtfs/just_gtfs.h
@@ -516,7 +516,7 @@ inline Time::Time(const std::string & raw_time_str) : raw_time(raw_time_str)
     return;
 
   const size_t len = raw_time.size();
-  if (!(len >= 7 && len <= 9) || (raw_time[len - 3] != ':' && raw_time[len - 6] != ':'))
+  if (!(len >= 7 && len <= 9) || raw_time[len - 3] != ':' || raw_time[len - 6] != ':')
     throw InvalidFieldFormat("Time is not in [[H]H]H:MM:SS format: " + raw_time_str);
 
   hh = static_cast<uint16_t>(std::stoi(raw_time.substr(0, len - 6)));

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -23,6 +23,14 @@ TEST_CASE("Time in HH:MM:SS format")
   CHECK_EQ(stop_time.get_total_seconds(), 39 * 60 * 60 + 45 * 60 + 30);
 }
 
+TEST_CASE("Time in HHH:MM:SS format")
+{
+  Time stop_time("103:05:21");
+  CHECK_EQ(stop_time.get_hh_mm_ss(), std::make_tuple(103, 5, 21));
+  CHECK_EQ(stop_time.get_raw_time(), "103:05:21");
+  CHECK_EQ(stop_time.get_total_seconds(), 103 * 60 * 60 + 5 * 60 + 21);
+}
+
 TEST_CASE("Time from integers 1")
 {
   Time stop_time(14, 30, 0);
@@ -44,6 +52,7 @@ TEST_CASE("Invalid time format")
   CHECK_THROWS_AS(Time("12/10/00"), const InvalidFieldFormat &);
   CHECK_THROWS_AS(Time("12:100:00"), const InvalidFieldFormat &);
   CHECK_THROWS_AS(Time("12:10:100"), const InvalidFieldFormat &);
+  CHECK_THROWS_AS(Time("12:10/10"), const InvalidFieldFormat &);
 }
 
 TEST_CASE("Time not provided")


### PR DESCRIPTION
>For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins.

таким образом, если на какую-то остановку транспорт прибывает на следующий день после дня отправления в час ночи, время будет 25:00:00, если через день -- 49:00:00. Есть достаточно длинные маршруты, у которых количество часов переваливает за 100. При этом маршрутов у которых переваливает за 999 вроде нет.